### PR TITLE
Reduce min SDK version to 12

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId "protect.gift_card_guard"
-        minSdkVersion 17
+        minSdkVersion 12
         targetSdkVersion 23
         versionCode 4
         versionName "0.3"


### PR DESCRIPTION
The selection of SDK 17 was arbitrarily based on the version
available on my device at the time. As no APIs are being used
at that level, a lower SDK version can be targeted.

All the APIs currently used by the application were available
in SDK 12+. Moving the min SDK version to 12.
