### PR TITLE
Remove requirement to have complete translations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,7 @@ android {
         disable "GoogleAppIndexingWarning"
         disable "ButtonStyle"
         disable "AlwaysShowAction"
+        disable "MissingTranslation"
     }
 
     // This is for Robolectric support for SDK 23

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -39,6 +39,6 @@
     <string name="debug_version_fmt">Versione: <xliff:g id="version">%s</xliff:g></string>
     <string name="app_revision_fmt">Informazione sulla revisione: <xliff:g id="app_revision_url">%s</xliff:g></string>
     <string name="app_libraries"><xliff:g id="app_name">%s</xliff:g> usa le seguenti librerie di terze parti: <xliff:g id="app_libraries_list">%s</xliff:g></string>
-    <!-- needs translated --><string name="image_resources"><xliff:g id="app_name">%s</xliff:g> uses image resources from: <xliff:g id="sound_sources_list">%s</xliff:g></string>
+
     <string name="ok">Ok</string>
 </resources>


### PR DESCRIPTION
Translations and completeness are now tracked on Transifex:

https://www.transifex.com/na-243/gift-card-guard